### PR TITLE
Feature: add SeekToAndLoadDataFromIndex || Upgrade to Reloaded.Memory 7.0

### DIFF
--- a/AFSLib.Test/AFSLib.Test.csproj
+++ b/AFSLib.Test/AFSLib.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -23,10 +23,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AFSLib.Test/Archive.cs
+++ b/AFSLib.Test/Archive.cs
@@ -85,5 +85,18 @@ namespace AFSLib.Test
             Assert.Equal(1896448, viewer.Entries[2].Offset);
             Assert.Equal(514993, viewer.Entries[2].Length);
         }
+
+        [Fact]
+        public void SeekToAndLoadDataFromIndex()
+        {
+            var fileStream = new FileStream(Assets.RealAfsFile, FileMode.Open);
+            int testIndex = 1;
+            var result = AfsArchive.SeekToAndLoadDataFromIndex(fileStream, testIndex);
+            Assert.Equal(1414255, result.Length);
+            fileStream.Close();
+
+            AfsArchive.TryFromFile(File.ReadAllBytes(Assets.RealAfsFile), out var realAfs);
+            Assert.Equal(realAfs.Files[testIndex].Data, result);
+        }
     }
 }

--- a/AFSLib/AFSLib.csproj
+++ b/AFSLib/AFSLib.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+    <Version>$(VersionPrefix)1.1.0</Version>
     <Authors>Sewer56</Authors>
     <Company />
     <Product />
@@ -15,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reloaded.Memory" Version="2.6.0" />
+    <PackageReference Include="Reloaded.Memory" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AFSLib/AfsArchive.cs
+++ b/AFSLib/AfsArchive.cs
@@ -72,6 +72,26 @@ namespace AFSLib
         }
 
         /// <summary>
+        /// Retrieves the data at the index without reading other portions of the archive.
+        /// 
+        /// Useful if dealing with large AFS files to stream known content indexes without loading the entire AFS file.
+        /// </summary>
+        /// <param name="stream">Stream pointing to AFS archive</param>
+        /// <param name="index">The entry index/audioId inside the AFS</param>
+        public static byte[] SeekToAndLoadDataFromIndex(Stream stream, int index)
+        {
+            var reader = new Reloaded.Memory.Streams.BufferedStreamReader(stream, sizeof(AfsFileEntry));
+            var seekAmount = sizeof(AfsHeader);
+            if (index != 0)
+                seekAmount += sizeof(AfsFileEntry) * index;
+            reader.Seek(seekAmount, SeekOrigin.Begin);
+            var entry = reader.Read<AfsFileEntry>();
+            byte[] result = reader.ReadBytes(entry.Offset, entry.Length);
+            reader.Dispose();
+            return result;
+        }
+
+        /// <summary>
         /// Tries to get an AFS archive from a given pointer.
         /// Operation fails if file is not an AFS file.
         /// </summary>

--- a/AFSLib/AfsFileViewer.cs
+++ b/AFSLib/AfsFileViewer.cs
@@ -83,7 +83,7 @@ namespace AFSLib
             for (var x = 0; x < Entries.Count; x++)
             {
                 var entry = Entries[x];
-                Memory.CurrentProcess.ReadRaw((IntPtr) GetAddress(entry.Offset), out byte[] data, entry.Length);
+                Memory.CurrentProcess.ReadRaw((nuint) GetAddress(entry.Offset), out byte[] data, entry.Length);
                 var afsFile = new File($"{x}", data);
 
                 if (Metadata != null)
@@ -116,12 +116,12 @@ namespace AFSLib
                 return false;
 
             filePointer += sizeof(AfsHeader);
-            Entries = new FixedArrayPtr<AfsFileEntry>((ulong) filePointer, Header->NumberOfFiles);
+            Entries = new FixedArrayPtr<AfsFileEntry>((UIntPtr) filePointer, Header->NumberOfFiles);
 
             filePointer += sizeof(AfsFileEntry) * Header->NumberOfFiles;
             var metadataEntries = (AfsFileEntry*)filePointer;
             if (metadataEntries->Length > 0 && metadataEntries->Offset > 0)
-                Metadata = new FixedArrayPtr<AfsFileMetadata>((ulong)GetAddress(metadataEntries->Offset), Header->NumberOfFiles);
+                Metadata = new FixedArrayPtr<AfsFileMetadata>((UIntPtr)GetAddress(metadataEntries->Offset), Header->NumberOfFiles);
 
             return true;
         }

--- a/AFSLib/AfsStructs/AfsFileMetadata.cs
+++ b/AFSLib/AfsStructs/AfsFileMetadata.cs
@@ -27,7 +27,7 @@ namespace AFSLib.AfsStructs
             set
             {
                 fixed (byte* fileNamePtr = _fileName)
-                    Memory.CurrentProcess.WriteRaw((IntPtr) fileNamePtr, Encoding.ASCII.GetBytes(value));
+                    Memory.CurrentProcess.WriteRaw((nuint) fileNamePtr, Encoding.ASCII.GetBytes(value));
             }
         }
 

--- a/AFSLib/AfsStructs/AfsHeader.cs
+++ b/AFSLib/AfsStructs/AfsHeader.cs
@@ -43,7 +43,7 @@ namespace AFSLib.AfsStructs
             for (int x = 0; x < TagLength; x++) 
                 header._tag[x] = 0;
 
-            Memory.CurrentProcess.WriteRaw((IntPtr) header._tag, Encoding.ASCII.GetBytes("AFS"));
+            Memory.CurrentProcess.WriteRaw((nuint) header._tag, Encoding.ASCII.GetBytes("AFS"));
             return header;
         }
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ if (AfsFileViewer.TryFromFile(data, out var afsViewer))
 };
 ```
 
+### Reading data from a single entry in an AFS File
+To get the data from a single entry inside an AFS with minimal memory footprint, use the static method:
+```csharp
+AfsArchive.SeekToAndLoadDataFromIndex(stream, index)
+```
+
+
+This will seek through the file and return a byte[] containing just the data at that index.
+This is useful for large AFS with one-off reads.
+
+
 ### Editing an AFS File
 To edit an AFS file, create an instance of `AfsArchive`.
 `AfsArchive` reads all of the data from an `AfsFileViewer`, converting it into a format easier to edit for the end user.


### PR DESCRIPTION
* Adds a method to load data from an index without requiring the entire byte[] being provided. Useful for large AFS without allocating to the LOH.
* Set lang to latest
* Upgrade test deps | Target .NET 6 (TestProj)
* Migrate to Reloaded.Memory 7.0
* Bump version to 1.1.0